### PR TITLE
remove compatibility do python 2 unicode -> to run in Django 3

### DIFF
--- a/jet/models.py
+++ b/jet/models.py
@@ -1,10 +1,8 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 
-@python_2_unicode_compatible
 class Bookmark(models.Model):
     url = models.URLField(verbose_name=_('URL'))
     title = models.CharField(verbose_name=_('title'), max_length=255)
@@ -20,7 +18,6 @@ class Bookmark(models.Model):
         return self.title
 
 
-@python_2_unicode_compatible
 class PinnedApplication(models.Model):
     app_label = models.CharField(verbose_name=_('application name'), max_length=255)
     user = models.PositiveIntegerField(verbose_name=_('user'))


### PR DESCRIPTION
v1.0.11 still doesn't support Django 3, @lejenome @carlosmonari, related to https://github.com/tikservices/django-jet2/pull/17