### PR TITLE
js: fixup gettext in django 3.1

### DIFF
--- a/jet/static/jet/js/src/utils/translate.js
+++ b/jet/static/jet/js/src/utils/translate.js
@@ -1,6 +1,7 @@
 module.exports = function(str) {
-    if (window.django == undefined) {
+    const gettext = django.gettext || window.gettext;
+    if (gettext == undefined) {
         return str;
     }
-    return django.gettext(str);
+    return gettext(str);
 };


### PR DESCRIPTION
For some reason in Django 3.1 django.gettext is not available anymore in the scope,
it's available as window.gettext though. Update translate.js to work
with both locations.

This was already reported here:
https://github.com/geex-arts/django-jet/issues/149

Fix #25

Haven't rebuilt the bundle because I have node 12 which requires upgrading at least gulp 4 and it didn't work out of the box.